### PR TITLE
Fixes nginx redirect to port 5000 when accessing url without slashes

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -30,6 +30,8 @@ http {
 
     server {
         listen 5000;
+        port_in_redirect off;
+
         location / {
             root "/app/";
             autoindex on;


### PR DESCRIPTION
Fixes nginx redirect to port 5000 when accessing url without slashes

http://serverfault.com/questions/351212/nginx-redirects-to-port-8080-when-accessing-url-without-slash
